### PR TITLE
Allow to configure desturl for duplicity

### DIFF
--- a/manifests/duplicity.pp
+++ b/manifests/duplicity.pp
@@ -79,6 +79,7 @@ define backupninja::duplicity (
   $keep = false,
   $bandwidthlimit = false,
   $sshoptions = false,
+  $desturl = false,
   $destdir = false,
   $desthost = false,
   $destuser = false,

--- a/templates/dup.conf.erb
+++ b/templates/dup.conf.erb
@@ -38,6 +38,7 @@
 <%= 'keep = ' + @keep if @keep %>
 <%= 'bandwidthlimit = ' + @bandwidthlimit if @bandwidthlimit %>
 <%= 'sshoptions = ' + @sshoptions if @sshoptions %>
+<%= 'desturl = ' + @desturl if @desturl %>
 <%= 'destdir = ' + @destdir if @destdir %>
 <%= 'desthost = ' + @desthost if @desthost %>
 <%= 'destuser = ' + @destuser if @destuser %>


### PR DESCRIPTION
In some situations (e.g. if I need to specify the protocol as sftp or pexpect+scp I want to be able to use the desturl instead of the parts of the desturl.